### PR TITLE
Solved matNs on sotreAndPlotResults script

### DIFF
--- a/sources/storeAndPlotResults.m
+++ b/sources/storeAndPlotResults.m
@@ -79,7 +79,7 @@ if timeIndex == 1
 end
 % initiate normalForces with initial values
 normalForces = normalForcesIni ;
-
+sigxs = modelCurrSol.Stress(:,1) ;
 if ~isempty(indsNormal) == 1
     for indexArea = 1:(size(crossSecsParamsMat,1))                    
         typeSec          = crossSecsParamsMat(indexArea,1)   ;


### PR DESCRIPTION
Solved issue #160 adding sigx vector for non inital time.

Verificated using cantieleverPendulum
![image](https://user-images.githubusercontent.com/50339940/106824306-593d9100-6661-11eb-9627-2c55c7145cc0.png)
